### PR TITLE
Update README.md - Change git clone to use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Only the **region server** is in a usable state, with **plugin support** in its 
 1. Install node.js v15.0.1 or later
 1. Download NodePolus
     - Either by downloading the zip [here](https://github.com/nodepolus/NodePolus/archive/main.zip)
-    - Or by cloning the repo via `git clone git@github.com:nodepolus/NodePolus.git`
+    - Or by cloning the repo via `git clone https://github.com/NodePolus/NodePolus.git`
 1. Open a terminal inside the extracted archive directory or the cloned repo directory
 1. Install the dependencies
     - If you downloaded the zip archive: `npm install --ignore-scripts`


### PR DESCRIPTION
Using `git clone git@github.com:nodepolus/NodePolus.git` does not work with for people without ssh keys. I have tried this on my machine, and it fails with the error below.
```
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
```

Developers with ssh keys enabled should know to clone with ssh anyway, and the README.md should work for people that do not have ssh set up with GitHub.