### PR TITLE
Map implementation example

### DIFF
--- a/lib/gameRoom.ts
+++ b/lib/gameRoom.ts
@@ -1,0 +1,70 @@
+import { MapType, RoomFromMap } from "./map";
+import { Player } from "./util/player";
+import { Vent } from "./vent";
+export enum SkeldRoom {
+  Reactor = "Reactor",
+  UpperEngine = "UpperEngine",
+  LowerEngine = "LowerEngine",
+  Security = "Security",
+  MedBay = "MedBay",
+  Electrical = "Electrical",
+  Cafeteria = "Cafeteria",
+  Storage = "Storage",
+  Admin = "Admin",
+  Communications = "Communications",
+  O2 = "O2",
+  Weapons = "Weapons",
+  Shields = "Shields",
+  Navigation = "Navigation",
+}
+
+export enum MiraHQRoom {
+  Launchpad = "Launchpad",
+  Reactor = "Reactor",
+  LockerRoom = "LockerRoom",
+  Communications = "Communications",
+  MedBay = "MedBay",
+  Office = "Office",
+  Admin = "Admin",
+  Greenhouse = "Greenhouse",
+  Storage = "Storage",
+  Cafeteria = "Cafeteria",
+  Balcony = "Balcony",
+}
+
+export enum PolusRoom {
+  Security = "Security",
+  O2 = "O2",
+  Electrical = "Electrical",
+  Communications = "Communications",
+  Weapons = "Weapons",
+  Storage = "Storage",
+  Office = "Office",
+  Admin = "Admin",
+  Laboratory = "Laboratory",
+  Specimen = "Specimen",
+}
+
+export interface GameRoom<R> {
+  name: R;
+  players: Player[];
+  doors: unknown[];
+  vents: Vent[];
+}
+
+export const createRoom = <
+  Map extends MapType,
+  PossibleRooms = RoomFromMap<Map>
+>(
+  name: PossibleRooms,
+  vents: Array<Vent> = []
+): GameRoom<PossibleRooms> => {
+  const room = {
+    name,
+    players: [],
+    doors: [],
+    vents: vents,
+  };
+
+  return room;
+};

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -1,0 +1,71 @@
+import {
+  GameRoom,
+  MiraHQRoom,
+  PolusRoom,
+  createRoom,
+  SkeldRoom,
+} from "./gameRoom";
+import { Vent } from "./vent";
+
+export enum MapType {
+  Skeld = "Skeld",
+  MiraHQ = "MiraHQ",
+  Polus = "Polus",
+}
+
+export type RoomFromMap<T> = T extends MapType.MiraHQ
+  ? MiraHQRoom
+  : T extends MapType.Skeld
+  ? SkeldRoom
+  : T extends MapType.Polus
+  ? PolusRoom
+  : never;
+
+export interface MapConfig<T> {
+  map: T;
+}
+
+export class Map<Type extends MapType, Rooms = RoomFromMap<Type>> {
+  config: MapConfig<Type>;
+  rooms: Array<GameRoom<Rooms>>;
+
+  constructor(config: MapConfig<Type>) {
+    this.config = config;
+    this.rooms = [];
+  }
+
+  getRoom(name: Rooms): GameRoom<Rooms> {
+    const room = this.rooms.find((r) => r.name === name);
+    if (!room) throw new Error("Could not find room: " + name);
+    return room;
+  }
+}
+
+export class MiraMap extends Map<MapType.MiraHQ> {
+  constructor() {
+    super({ map: MapType.MiraHQ });
+
+    const reactorVent = new Vent();
+    const launchpadVent = new Vent();
+    const laboratoryVent = new Vent();
+    const ventUnderDecontamination = new Vent();
+
+    reactorVent.addConnections(launchpadVent, laboratoryVent);
+    launchpadVent.addConnections(reactorVent, ventUnderDecontamination);
+
+    this.rooms.push(createRoom(MiraHQRoom.Reactor, [reactorVent]));
+    this.rooms.push(createRoom(MiraHQRoom.LockerRoom));
+    this.rooms.push(createRoom(MiraHQRoom.Communications));
+    this.rooms.push(createRoom(MiraHQRoom.MedBay));
+    this.rooms.push(createRoom(MiraHQRoom.Office));
+    this.rooms.push(createRoom(MiraHQRoom.Admin));
+    this.rooms.push(createRoom(MiraHQRoom.Greenhouse));
+    this.rooms.push(createRoom(MiraHQRoom.Storage));
+    this.rooms.push(createRoom(MiraHQRoom.Cafeteria));
+    this.rooms.push(createRoom(MiraHQRoom.Balcony));
+    this.rooms.push(createRoom(MiraHQRoom.Launchpad, [launchpadVent]));
+  }
+}
+
+const m = new MiraMap();
+console.log(m.getRoom(MiraHQRoom.Reactor));

--- a/lib/vent.ts
+++ b/lib/vent.ts
@@ -1,0 +1,15 @@
+import { Player } from "./util/player";
+
+export class Vent {
+  player: Player | null;
+  connections: Array<Vent>;
+
+  constructor(connections: Array<Vent> = []) {
+    this.player = null;
+    this.connections = connections;
+  }
+
+  addConnections(...connections: Array<Vent>) {
+    this.connections = [...this.connections, ...connections];
+  }
+}


### PR DESCRIPTION
This is more of a 'do not merge' branch, as an example of how we could go implementing maps and rooms in a much more type-safe way than currently done in the game-data branch.

This ensures specific game rooms are created only on their correct map instances, and uses some fancy other generics and stuff to dedupe a bunch of game data. Ideally the rooms, connections, vents etc would all be data-driven instead of hardcoded, and we can remove the need for a `MiraMap` (etc) that takes the base `Map` and does configuration. We'd just create a new map `const map = new Map(MapType.MiraHQ)` and it would configure itself properly.